### PR TITLE
Fix the "Zone Transfer" Bug

### DIFF
--- a/setup
+++ b/setup
@@ -70,6 +70,7 @@ function update_configs {
     echo "
 zone \"${DOMAIN_NAME}\" {
       type master;
+      allow-transfer { none; };
       file \"/etc/bind/db.local\";
 };
     " >> "${BASE_BIND_PATH}/named.conf.default-zones"


### PR DESCRIPTION
Referring to the following article, if the zone transfer feature is not disabled, the attacker can copy the entire content of the DNS database and abuse that information :

https://yogesh-verma.medium.com/zone-transfer-attacks-a-practical-guide-to-detection-and-prevention-2e8346d0297e